### PR TITLE
Update ColorOverlayEffect.cs

### DIFF
--- a/Flex.iOS/Effects/ColorOverlayEffect.cs
+++ b/Flex.iOS/Effects/ColorOverlayEffect.cs
@@ -36,7 +36,10 @@ namespace Flex.iOS.Effects
             var formsImage = (Xamarin.Forms.Image)Element;
             if (formsImage?.Source == null)
                 return;
-
+                
+            if (formsImage?.IsLoading == true)            
+                return;          
+            
             try
             {
                 UIImage image = ((UIImageView)Control).Image;


### PR DESCRIPTION
Fixed bug when EmbeddedResource couldn't be used as Icon. More detailed described in bug_report.md.